### PR TITLE
Fix "not exported from module" error in Pyright

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
-    branches:
-      - main
 
 defaults:
   run:

--- a/src/case_insensitive_dict/__init__.py
+++ b/src/case_insensitive_dict/__init__.py
@@ -15,3 +15,5 @@ except PackageNotFoundError:
 from .case_insensitive_dict import CaseInsensitiveDict
 from .case_insensitive_dict import CaseInsensitiveDictJSONEncoder
 from .case_insensitive_dict import case_insensitive_dict_json_decoder
+
+__all__ = ['CaseInsensitiveDict', 'CaseInsensitiveDictJSONEncoder', 'case_insensitive_dict_json_decoder']


### PR DESCRIPTION
Without this change, Pyright reports this error:

```
"CaseInsensitiveDict" is not exported from module "case_insensitive_dict"
  Import from "case_insensitive_dict.case_insensitive_dict" instead
```

Upstream Pyright seems to have confirmed the behavior is intended and libraries need to be explicit about which symbols are considered public. (See the linked docs in microsoft/pyright#2277)

The other alternative seems to be modifying the imports in `__init__.py` to have aliases, like this:

```
from .case_insensitive_dict import CaseInsensitiveDict as CaseInsensitiveDict
from .case_insensitive_dict import CaseInsensitiveDictJSONEncoder as CaseInsensitiveDictJSONEncoder
from .case_insensitive_dict import case_insensitive_dict_json_decoder as case_insensitive_dict_json_decoder
```

but that requires adding:

```
# pylint: disable=useless-import-alias
```

Let me know if you think there's a better way to address this.

Thanks!