### PR TITLE
Added kwargs support in __init__

### DIFF
--- a/case_insensitive_dict/case_insensitive_dict.py
+++ b/case_insensitive_dict/case_insensitive_dict.py
@@ -27,19 +27,19 @@ else:
 
 class CaseInsensitiveDict(MutableMapping, Generic[KT, VT]):
     @overload
-    def __init__(self, data: Optional[Mapping[KT, VT]] = None) -> None:
+    def __init__(self, data: Optional[Mapping[KT, VT]] = None, **kwargs) -> None:
         ...
 
     @overload
-    def __init__(self, data: Optional[Iterable[Tuple[KT, VT]]] = None) -> None:
+    def __init__(self, data: Optional[Iterable[Tuple[KT, VT]]] = None, **kwargs) -> None:
         ...
 
-    def __init__(self, data: Optional[Union[Mapping[KT, VT], Iterable[Tuple[KT, VT]]]] = None) -> None:
+    def __init__(self, data: Optional[Union[Mapping[KT, VT], Iterable[Tuple[KT, VT]]]] = None, **kwargs) -> None:
         # Mapping from lowercased key to tuple of (actual key, value)
         self._data: Dict[KT, Tuple[KT, VT]] = {}
         if data is None:
             data = {}
-        self.update(data)
+        self.update(data, **kwargs)
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({dict(self.items())!r})'

--- a/case_insensitive_dict/case_insensitive_dict.py
+++ b/case_insensitive_dict/case_insensitive_dict.py
@@ -27,14 +27,14 @@ else:
 
 class CaseInsensitiveDict(MutableMapping, Generic[KT, VT]):
     @overload
-    def __init__(self, data: Optional[Mapping[KT, VT]] = None, **kwargs) -> None:
+    def __init__(self, data: Optional[Mapping[KT, VT]] = None, **kwargs: VT) -> None:
         ...
 
     @overload
-    def __init__(self, data: Optional[Iterable[Tuple[KT, VT]]] = None, **kwargs) -> None:
+    def __init__(self, data: Optional[Iterable[Tuple[KT, VT]]] = None, **kwargs: VT) -> None:
         ...
 
-    def __init__(self, data: Optional[Union[Mapping[KT, VT], Iterable[Tuple[KT, VT]]]] = None, **kwargs) -> None:
+    def __init__(self, data: Optional[Union[Mapping[KT, VT], Iterable[Tuple[KT, VT]]]] = None, **kwargs: VT) -> None:
         # Mapping from lowercased key to tuple of (actual key, value)
         self._data: Dict[KT, Tuple[KT, VT]] = {}
         if data is None:


### PR DESCRIPTION
Added kwargs support in __init__, like in built-in `dict`.

Fixes #100 

```python
In [1]: from case_insensitive_dict import CaseInsensitiveDict

In [2]: cid = CaseInsensitiveDict(a=1)

In [3]: cid
Out[3]: CaseInsensitiveDict({'a': 1})
```
```python
In [4]: cid = CaseInsensitiveDict({'a': 1}, b=2)

In [5]: cid
Out[5]: CaseInsensitiveDict({'a': 1, 'b': 2})

```
```python
In [6]: cid = CaseInsensitiveDict([['a', 1]], b=2)

In [7]: cid
Out[7]: CaseInsensitiveDict({'a': 1, 'b': 2})
```